### PR TITLE
Write the developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,152 +1,139 @@
-# WordPress Development Toolkit
+<div align="center">
 
-WordPress Development Toolkit is a comprehensive plugin designed to assist WordPress developers in their plugin development process. It provides a set of tools and utilities to streamline development, debugging, and performance optimization.
+# WordPress Development Toolkit — Developer Guide
+
+**Error log, query monitor and hook inspector behind one React admin — and a registry that lets a plugin add a fourth tool without touching this one.**
+
+[![Version](https://img.shields.io/badge/version-1.0.0-2563eb.svg)](https://github.com/mralaminahamed/wp-dev-toolkit)
+[![WordPress](https://img.shields.io/badge/WordPress-5.8%2B-21759b.svg?logo=wordpress&logoColor=white)](https://wordpress.org/)
+[![PHP](https://img.shields.io/badge/PHP-7.4%2B-777BB4.svg?logo=php&logoColor=white)](https://php.net/)
+[![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL--2.0--or--later-green.svg)](LICENSE)
+
+</div>
+
+## What it is
+
+Debugging a WordPress site means three habits: reading the error log, watching
+what the page asked the database, and finding out which callback is on the hook
+that is misbehaving. Each has a plugin of its own, each brings its own admin
+page, and none of them agrees with the others about where anything lives.
+
+This is those three behind one screen. The part that matters architecturally is
+that "those three" is not a fixed list: a tool is any class implementing a
+two-method interface, the factory holds a registry of them, and
+`wp_dev_toolkit_default_tools` lets another plugin add its own — which then
+appears in the same UI, with the same REST plumbing, without this plugin knowing
+its name.
 
 ## Features
 
-- Development Mode Toggle
-- Error Logging and Viewer
-- Database Query Monitor
-- WordPress Hook Inspector
-- Terminal Interface for Commands
-- React-based Admin Interface with Tailwind CSS
-- REST API Integration
-- Extensible Architecture
-
-## Tailwind CSS Configuration
-
-This plugin uses Tailwind CSS 3 with a custom prefix (`wdt-`) to avoid conflicts with WordPress styles. Here's how it's configured:
-
-### Key Features
-
-- Custom prefix (`wdt-`) for all Tailwind classes to prevent conflicts with WordPress core
-- Extended color palette based on WordPress admin colors
-- Custom fonts matching WordPress admin interface
-- PostCSS configuration for optimal processing
-- Responsive design utility classes
-
-### Usage Example
-
-```jsx
-// Using Tailwind with prefix
-<div className="wdt-flex wdt-items-center wdt-gap-3 wdt-p-4">
-  <div className="wdt-bg-primary-500 wdt-text-white wdt-p-3 wdt-rounded-lg">
-    Primary Color Box
-  </div>
-</div>
-```
-
-### Files
-
-- `tailwind.config.js` - Main Tailwind configuration
-- `postcss.config.js` - PostCSS configuration for Tailwind
-- `src/styles/index.scss` - Main stylesheet with Tailwind imports and custom styles
-- `src/components/TailwindTest.tsx` - Example component demonstrating Tailwind usage
-
-## Installation
-
-1. Download the plugin zip file or clone the repository:
-   ```bash
-   git clone https://github.com/mralaminahamed/wp-dev-toolkit.git
-   ```
-
-2. Navigate to the plugin directory and install dependencies:
-   ```bash
-   cd wp-dev-toolkit
-   composer install
-   npm install
-   ```
-
-3. Build the assets:
-   ```bash
-   npm run build
-   ```
-
-4. Activate the plugin through the WordPress admin interface.
+- **Error logger** — read and filter the log without SSH
+- **Query monitor** — what the request asked the database, and how long it took
+- **Hook inspector** — what is attached to a hook, in priority order
+- **React admin** for all three, so a tool ships a UI without building an admin page
+- **Extensible** — register a tool from your own plugin through one filter
+- REST routes per tool, declared by the tool itself
 
 ## Requirements
 
-- WordPress 5.8 or higher
-- PHP 7.4 or higher
-- Node.js 14 or higher
-- Composer
+- WordPress 5.8+
+- PHP 7.4+
 
-## Usage
+Development additionally needs Node for the admin bundle.
 
-After activation, you'll find a new "Dev Toolkit" menu item in your WordPress admin panel. From there, you can access various development tools:
+## Installation
 
-1. **Dashboard**: Toggle development mode and view overall statistics.
-2. **Error Log**: View and manage the WordPress error log.
-3. **Query Monitor**: Inspect database queries made during page loads.
-4. **Hook Inspector**: View all WordPress hooks fired during page execution.
-5. **Terminal**: Execute commands in a controlled environment.
-6. **Settings**: Configure the toolkit options.
-
-## Configuration
-
-You can configure the plugin through the Settings interface or programmatically:
-
-```php
-use WPDevToolkit\Admin\Config;
-
-$config = new Config();
-$config->update([
-    'error_logger' => true,
-    'query_monitor' => true,
-    'hook_inspector' => true,
-]);
+```bash
+git clone https://github.com/mralaminahamed/wp-dev-toolkit.git
+cd wp-dev-toolkit
+composer install
+yarn install && yarn build
 ```
-
-## Extending the Toolkit
-
-You can add your own tools to the toolkit using the provided hook:
-
-```php
-add_action('wp_dev_toolkit_init', function($plugin) {
-    $plugin->register_tool('my_custom_tool', MyCustomTool::class);
-});
-```
-
-Your custom tool class should implement the `WPDevToolkit\Tools\ToolInterface` interface.
 
 ## Development
 
-### Frontend Development
-
-The admin interface is built with React and Tailwind CSS:
-
 ```bash
-# Watch for changes during development
-npm run start
+composer phpcs      # WordPress coding standards
+composer phpcbf     # auto-fix what it can
+composer phpstan    # static analysis
+composer test       # PHPUnit
 
-# Build for production
-npm run build
+yarn dev            # asset watch
+yarn build          # production bundle
+yarn check-types    # tsc --noEmit
+yarn lint           # ESLint
+yarn test           # Jest
 ```
 
-### Backend Development
+## Architecture
 
-The plugin follows WordPress coding standards. Run code quality checks with:
-
-```bash
-# PHP CodeSniffer
-composer run phpcs
-
-# PHPStan analysis
-composer run phpstan
 ```
+wp-dev-toolkit.php            entry point and constants
+class-wp-dev-toolkit.php      singleton; boots the admin and the tools
+includes/
+├── Tools/
+│   ├── ToolInterface.php     init() and register_rest_routes() — the entire contract
+│   ├── ToolBase.php          shared behaviour for the tools that want it
+│   ├── Factory.php           the registry: register(), create(), get_registered_tools()
+│   ├── ErrorLogger.php
+│   ├── QueryMonitor.php
+│   └── HookInspector.php
+├── Admin/
+│   ├── Menu.php              the admin page
+│   ├── Assets.php            the React bundle
+│   └── Config.php            what the frontend is told about the tools
+└── Utilities/Helpers.php
+resources/docs/               scope notes — see Documentation below
+```
+
+### A tool is two methods
+
+```php
+interface ToolInterface {
+    public function init(): void;
+    public function register_rest_routes(): void;
+}
+```
+
+That is the whole contract. A tool sets up its own hooks and declares its own
+REST routes; nothing else in the plugin knows what any particular tool does. The
+factory validates on registration — the class must exist and must implement the
+interface — so a typo in a third-party registration fails at registration with a
+clear exception rather than fataling later on a missing method.
+
+### Adding a tool from another plugin
+
+```php
+add_filter( 'wp_dev_toolkit_default_tools', function ( array $tools ) {
+    $tools['my_tool'] = My_Plugin\\Tools\\My_Tool::class;
+    return $tools;
+} );
+```
+
+The filter runs over the default map before anything is registered, so a third
+party can add to it, replace one of the built-ins, or remove one entirely by
+unsetting its key.
+
+### Data
+
+No custom tables. The tools read what WordPress and the database already expose —
+the log file, the query log, the global hook array — and store nothing of their
+own, which is what makes the plugin safe to deactivate on a site that is
+misbehaving.
+
+## Documentation
+
+Scope notes for each layer live in [`resources/docs/`](resources/docs/index.md):
+[tools](resources/docs/tools-scope.md) ·
+[admin](resources/docs/admin-scope.md) ·
+[REST](resources/docs/rest-scope.md) ·
+[frontend](resources/docs/frontend-scope.md)
 
 ## Contributing
 
-We welcome contributions to the WordPress Development Toolkit! Please see our [Contributing Guidelines](CONTRIBUTING.md) for more information on how to get started.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) and the
+[code of conduct](CODE_OF_CONDUCT.md).
 
 ## License
 
-This project is licensed under the GPL v2 or later. See the [LICENSE](LICENSE) file for details.
-
-## Support
-
-If you encounter any issues or have questions, please [open an issue](https://github.com/mralaminahamed/wp-dev-toolkit/issues) on our GitHub repository.
-
-## Acknowledgements
-
-This plugin was developed with the help of the WordPress community and uses various open-source libraries and tools. We're grateful for their contributions to the ecosystem.
+GPL-2.0-or-later. See [`LICENSE`](LICENSE).


### PR DESCRIPTION
The headings ran "Features, Tailwind CSS Configuration, Key Features, Usage Example, Files" — a build detail promoted above what the plugin is.

It now leads with the thing that actually shapes the code: **a tool is any class implementing a two-method interface**.

```php
interface ToolInterface {
    public function init(): void;
    public function register_rest_routes(): void;
}
```

The factory is a registry over that interface, and `wp_dev_toolkit_default_tools` runs over the default map before anything is registered — so another plugin can add a tool, replace a built-in, or unset one, and it appears in the same React admin with the same REST plumbing without this plugin knowing its name. The filter example is in the guide.

Also recorded: `Factory::register()` validates that the class exists and implements the interface, so a third-party typo fails at registration with a clear exception rather than fataling later on a missing method. And the tools store nothing of their own — they read the log file, the query log and the global hook array — which is what makes the plugin safe to deactivate on a site that is already misbehaving.

Kept the pointers to `resources/docs/` rather than restating them.